### PR TITLE
EE-7270 Enforcing TLSv1.2 for all HMRC API calls

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/SpringConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/SpringConfiguration.java
@@ -3,10 +3,15 @@ package uk.gov.digital.ho.pttg.application;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContexts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.client.RestTemplate;
@@ -17,6 +22,7 @@ import uk.gov.digital.ho.pttg.api.RequestData;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.ZoneId;
+import java.util.List;
 
 @Configuration
 @EnableRetry
@@ -27,19 +33,23 @@ public class SpringConfiguration implements WebMvcConfigurer {
     private final String proxyHost;
     private final Integer proxyPort;
     private final TimeoutProperties timeoutProperties;
+    private final String[] supportedSslProtocols;
 
     SpringConfiguration(ObjectMapper objectMapper,
                         @Value("${proxy.enabled:false}") boolean useProxy,
                         @Value("${hmrc.endpoint:}") String hmrcBaseUrl,
                         @Value("${proxy.host:}") String proxyHost,
                         @Value("${proxy.port}") Integer proxyPort,
-                        TimeoutProperties timeoutProperties
+                        TimeoutProperties timeoutProperties,
+                        @Value("#{'${hmrc.ssl.supportedProtocols}'.split(',')}") List<String> supportedSslProtocols
     ) {
         this.useProxy = useProxy;
         this.hmrcBaseUrl = hmrcBaseUrl;
         this.proxyHost = proxyHost;
         this.proxyPort = proxyPort;
         this.timeoutProperties = timeoutProperties;
+        this.supportedSslProtocols = supportedSslProtocols.toArray(new String[]{});
+        
         initialiseObjectMapper(objectMapper);
     }
 
@@ -62,14 +72,31 @@ public class SpringConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    RestTemplate hmrcRestTemplate(RestTemplateBuilder restTemplateBuilder, ObjectMapper mapper) {
+    RestTemplate hmrcRestTemplate(RestTemplateBuilder restTemplateBuilder, ObjectMapper mapper, ClientHttpRequestFactory clientHttpRequestFactory) {
         RestTemplateBuilder builder = initaliseRestTemplateBuilder(restTemplateBuilder, mapper);
 
         return builder
                 .setReadTimeout(timeoutProperties.getHmrc().getReadMs())
                 .setConnectTimeout(timeoutProperties.getHmrc().getConnectMs())
+                .requestFactory(() -> clientHttpRequestFactory)
                 .build();
     }
+
+    @Bean
+    public ClientHttpRequestFactory createClientHttpRequestFactory(HttpClientBuilder builder) {
+
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setHttpClient(builder.build());
+
+        return factory;
+    }
+
+    @Bean
+    public HttpClientBuilder createHttpClientBuilder() {
+        final SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(SSLContexts.createDefault(), supportedSslProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+        return HttpClientBuilder.create().setSSLSocketFactory(sslSocketFactory);
+    }
+
 
     private RestTemplateBuilder initaliseRestTemplateBuilder(RestTemplateBuilder restTemplateBuilder, ObjectMapper mapper) {
         RestTemplateBuilder builder = restTemplateBuilder;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,7 @@ info.app.version=${version:0.0.1}
 base.hmrc.url=https://test-developer.service.hmrc.gov.uk
 hmrc.endpoint=${base.hmrc.url}
 
+hmrc.ssl.supportedProtocols=TLSv1.2
 
 #
 # Audit

--- a/src/test/java/uk/gov/digital/ho/pttg/application/SpringConfigurationTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/SpringConfigurationTest.java
@@ -13,10 +13,13 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
@@ -31,7 +34,7 @@ public class SpringConfigurationTest {
     private RestTemplate mockRestTemplate;
 
     private TimeoutProperties restTemplateProperties;
-    private final List<String> anySSLProtocols = new ArrayList<>();
+    private final List<String> allowedSslProtocols = Collections.singletonList("TLSv1.2");
 
     @Before
     public void setUp() {
@@ -52,7 +55,7 @@ public class SpringConfigurationTest {
     public void shouldUseCustomizerWhenProxyEnabled() {
 
         SpringConfiguration config = new SpringConfiguration(new ObjectMapper(),
-                true, "", "host", 1234, restTemplateProperties, anySSLProtocols);
+                true, "", "host", 1234, restTemplateProperties, allowedSslProtocols);
         config.auditRestTemplate(mockRestTemplateBuilder, new ObjectMapper());
         verify(mockRestTemplateBuilder).additionalCustomizers(any(ProxyCustomizer.class));
     }
@@ -61,7 +64,7 @@ public class SpringConfigurationTest {
     public void shouldNotUseCustomizerByWhenProxyDisabled() {
 
         SpringConfiguration config = new SpringConfiguration(new ObjectMapper(),
-                false, null, null, null, restTemplateProperties, anySSLProtocols);
+                false, null, null, null, restTemplateProperties, allowedSslProtocols);
         config.auditRestTemplate(mockRestTemplateBuilder, new ObjectMapper());
         verify(mockRestTemplateBuilder, never()).additionalCustomizers(any(ProxyCustomizer.class));
     }
@@ -75,7 +78,7 @@ public class SpringConfigurationTest {
         restTemplateProperties.getAudit().setReadMs(readTimeout);
         restTemplateProperties.getAudit().setConnectMs(connectTimeout);
         SpringConfiguration springConfig = new SpringConfiguration(new ObjectMapper(),
-                false, null, null, null, restTemplateProperties, anySSLProtocols);
+                false, null, null, null, restTemplateProperties, allowedSslProtocols);
 
         // when
         RestTemplate restTemplate = springConfig.auditRestTemplate(mockRestTemplateBuilder, new ObjectMapper());
@@ -96,7 +99,7 @@ public class SpringConfigurationTest {
         restTemplateProperties.getHmrc().setReadMs(readTimeout);
         restTemplateProperties.getHmrc().setConnectMs(connectTimeout);
         SpringConfiguration springConfig = new SpringConfiguration(new ObjectMapper(),
-                false, null, null, null, restTemplateProperties, anySSLProtocols);
+                false, null, null, null, restTemplateProperties, allowedSslProtocols);
 
         // when
         final ClientHttpRequestFactory clientHttpRequestFactory = springConfig.createClientHttpRequestFactory(springConfig.createHttpClientBuilder());
@@ -107,5 +110,28 @@ public class SpringConfigurationTest {
         verify(mockRestTemplateBuilder).setConnectTimeout(connectTimeout);
 
         assertThat(restTemplate).isEqualTo(mockRestTemplate);
+    }
+
+    @Test
+    public void shouldThrowIllegalStateExceptionWhenNotTlsV1_2() {
+        List<String> sslV3Only = Arrays.asList("SSLv3");
+        List<String> tlsV1_1Only = Arrays.asList("TLSv1.1");
+        List<String> tlsV1_2PlusTlsV1_0 = Arrays.asList("TLSv1.2", "TLSv1.0");
+        List<String> noSsl = new ArrayList<>();
+
+        List<List<String>> sslProtocolPermutations = Arrays.asList(sslV3Only, tlsV1_1Only, tlsV1_2PlusTlsV1_0);
+
+        for (List<String> sslProtocols : sslProtocolPermutations) {
+            SpringConfiguration springConfiguration = new SpringConfiguration(new ObjectMapper(),false, null, null, null, restTemplateProperties, sslProtocols);
+            String expectedErrorMessage = String.format("Invalid TLS/SSL version: %s - only TLSv1.2 permitted.", sslProtocols.get(sslProtocols.size() - 1));
+            assertThatThrownBy(springConfiguration::createHttpClientBuilder)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(expectedErrorMessage);
+        }
+
+        SpringConfiguration springConfiguration =new SpringConfiguration(new ObjectMapper(),false, null, null, null, restTemplateProperties, noSsl);
+        assertThatThrownBy(springConfiguration::createHttpClientBuilder)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid TLS/SSL version: None - only TLSv1.2 permitted.");
     }
 }


### PR DESCRIPTION
Made it so that the RestTemplate used to communicate with the HMRC API will only use TLSv1.2. 

There is no automated test associated with this change because it was not feasible. The code inside the Java/Apache libraries that this code affects is far to complicated to realistically inspect its state through reflection. And developing some sort of mock server that we control the TLS version for in order to test against is a lot of work for a comparatively small gain.