### PR TITLE
EE-12327: Add event IDs for access code logs, add unit tests

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/application/LogEvent.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/LogEvent.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.pttg.application;
 
 public enum LogEvent {
     HMRC_ACCESS_CODE_SERVICE_STARTED,
+    HMRC_GET_ACCESS_CODE_SUCCESS,
     HMRC_PROXY_ENABLED,
     HMRC_ACCESS_CODE_REFRESH_REQUESTED,
     HMRC_ACCESS_CODE_REPORTED,

--- a/src/main/java/uk/gov/digital/ho/pttg/hmrc/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/hmrc/HmrcClient.java
@@ -21,6 +21,7 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.digital.ho.pttg.application.ApplicationExceptions.HmrcAccessCodeServiceRuntimeException;
 import static uk.gov.digital.ho.pttg.application.LogEvent.EVENT;
 import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_ACCESS_CODE_RESPONSE_SUCCESS;
+import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_GET_ACCESS_CODE_SUCCESS;
 
 
 @Component
@@ -73,7 +74,7 @@ public class HmrcClient {
             }
         }
 
-        log.info("Received access code response", value(EVENT, HMRC_ACCESS_CODE_RESPONSE_SUCCESS));
+        log.info("Received access code response", value(EVENT, HMRC_GET_ACCESS_CODE_SUCCESS));
         return accessCode;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/hmrc/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/hmrc/HmrcClient.java
@@ -13,11 +13,14 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.pttg.application.ApplicationExceptions;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.digital.ho.pttg.application.ApplicationExceptions.HmrcAccessCodeServiceRuntimeException;
-
+import static uk.gov.digital.ho.pttg.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_ACCESS_CODE_RESPONSE_SUCCESS;
 
 
 @Component
@@ -29,7 +32,7 @@ public class HmrcClient {
     private final String accessTokenResource;
 
     @Autowired
-    public HmrcClient(@Qualifier(value = "hmrcRestTemplate") RestTemplate restTemplate,
+    HmrcClient(@Qualifier(value = "hmrcRestTemplate") RestTemplate restTemplate,
                       @Value("${client.id}") String clientId,
                       @Value("${hmrc.endpoint}") String baseHmrcUrl) {
         this.restTemplate = restTemplate;
@@ -70,7 +73,7 @@ public class HmrcClient {
             }
         }
 
-        log.info("Received access code response");
+        log.info("Received access code response", value(EVENT, HMRC_ACCESS_CODE_RESPONSE_SUCCESS));
         return accessCode;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/hmrc/HmrcClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/hmrc/HmrcClient.java
@@ -20,7 +20,6 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.digital.ho.pttg.application.ApplicationExceptions.HmrcAccessCodeServiceRuntimeException;
 import static uk.gov.digital.ho.pttg.application.LogEvent.EVENT;
-import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_ACCESS_CODE_RESPONSE_SUCCESS;
 import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_GET_ACCESS_CODE_SUCCESS;
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,7 +34,7 @@ info.app.version=${version:0.0.1}
 #
 # HMRC endpoints
 #
-base.hmrc.url=https://test-developer.service.hmrc.gov.uk
+base.hmrc.url=http://localhost:4000
 hmrc.endpoint=${base.hmrc.url}
 
 hmrc.ssl.supportedProtocols=TLSv1.2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,7 +34,7 @@ info.app.version=${version:0.0.1}
 #
 # HMRC endpoints
 #
-base.hmrc.url=http://localhost:4000
+base.hmrc.url=https://test-developer.service.hmrc.gov.uk
 hmrc.endpoint=${base.hmrc.url}
 
 hmrc.ssl.supportedProtocols=TLSv1.2

--- a/src/test/java/uk/gov/digital/ho/pttg/hmrc/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/hmrc/HmrcClientTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.digital.ho.pttg.application.LogEvent.EVENT;
 import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_ACCESS_CODE_RESPONSE_SUCCESS;
+import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_GET_ACCESS_CODE_SUCCESS;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HmrcClientTest {
@@ -136,7 +137,7 @@ public class HmrcClientTest {
             LoggingEvent loggingEvent = (LoggingEvent) argument;
 
             return loggingEvent.getFormattedMessage().equals("Received access code response") &&
-                    (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_ACCESS_CODE_RESPONSE_SUCCESS));
+                    (loggingEvent.getArgumentArray()[0]).equals(new ObjectAppendingMarker(EVENT, HMRC_GET_ACCESS_CODE_SUCCESS));
         }));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/hmrc/HmrcClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/hmrc/HmrcClientTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.digital.ho.pttg.application.LogEvent.EVENT;
-import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_ACCESS_CODE_RESPONSE_SUCCESS;
 import static uk.gov.digital.ho.pttg.application.LogEvent.HMRC_GET_ACCESS_CODE_SUCCESS;
 
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
Add event IDs to log events when sending a successful response to HMRC.
